### PR TITLE
chore: release main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1272,14 +1272,14 @@
       }
     },
     "packages/package-a": {
-      "version": "0.0.1-next.26",
+      "version": "0.1.0-next.26",
       "license": "ISC"
     },
     "packages/package-b": {
-      "version": "0.0.1-next.26",
+      "version": "0.1.0-next.26",
       "license": "ISC",
       "dependencies": {
-        "package-a": "0.0.1-next.26"
+        "package-a": "0.1.0-next.26"
       }
     }
   }

--- a/packages/package-a/docs/changelog.md
+++ b/packages/package-a/docs/changelog.md
@@ -1,1 +1,24 @@
 # Changelog
+
+## [0.1.0-next.26](https://github.com/obany/changelog/compare/package-a-v0.0.1-next.26...package-a-v0.1.0-next.26) (2025-03-21)
+
+
+### Features
+
+* add index ([4db06e7](https://github.com/obany/changelog/commit/4db06e7a1f16a4b04f73739e10c54dcfd6d71db7))
+* extra-files ([550996a](https://github.com/obany/changelog/commit/550996ae841df19ecd6713f75444f4d5b75baa57))
+* include dot in next prerelease type ([090bbdf](https://github.com/obany/changelog/commit/090bbdff4466909bbdaaf27a61dd0d1bf8bac4d2))
+* include dot in next prerelease type ([f627ab9](https://github.com/obany/changelog/commit/f627ab9c3b24536b1b59aae93333e982efef9773))
+* initial commit ([b9378bc](https://github.com/obany/changelog/commit/b9378bc2766ab8c0f693c839d37e3e345eadde71))
+* initial commit ([6d7e83e](https://github.com/obany/changelog/commit/6d7e83e5be444b7e470a04771efce6cb8de1ac4f))
+* package a update ([79055ed](https://github.com/obany/changelog/commit/79055ede87bb9a8df9bf9395597df97f4f7dbf36))
+* update ([af48137](https://github.com/obany/changelog/commit/af4813774073de10838b9a8c2bce220bd02fc198))
+* update index ([3a2fc61](https://github.com/obany/changelog/commit/3a2fc61aced046b3e10ffae16d344dc66093e504))
+
+
+### Bug Fixes
+
+* changelog paths ([c1a8770](https://github.com/obany/changelog/commit/c1a8770443c49091e15af80d6a3dec4b74dbf4b7))
+* generate-release-configs ([2be7d43](https://github.com/obany/changelog/commit/2be7d431deef5e7fd0442d3c509b91a2d2464597))
+
+## Changelog

--- a/packages/package-a/package.json
+++ b/packages/package-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-a",
-  "version": "0.0.1-next.26",
+  "version": "0.1.0-next.26",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/package-b/docs/changelog.md
+++ b/packages/package-b/docs/changelog.md
@@ -1,1 +1,32 @@
 # Changelog
+
+## [0.1.0-next.26](https://github.com/obany/changelog/compare/package-b-v0.0.1-next.26...package-b-v0.1.0-next.26) (2025-03-21)
+
+
+### Features
+
+* add index ([4db06e7](https://github.com/obany/changelog/commit/4db06e7a1f16a4b04f73739e10c54dcfd6d71db7))
+* extra-files ([550996a](https://github.com/obany/changelog/commit/550996ae841df19ecd6713f75444f4d5b75baa57))
+* include dot in next prerelease type ([090bbdf](https://github.com/obany/changelog/commit/090bbdff4466909bbdaaf27a61dd0d1bf8bac4d2))
+* include dot in next prerelease type ([f627ab9](https://github.com/obany/changelog/commit/f627ab9c3b24536b1b59aae93333e982efef9773))
+* initial commit ([b9378bc](https://github.com/obany/changelog/commit/b9378bc2766ab8c0f693c839d37e3e345eadde71))
+* initial commit ([6d7e83e](https://github.com/obany/changelog/commit/6d7e83e5be444b7e470a04771efce6cb8de1ac4f))
+* package b update ([e2036d5](https://github.com/obany/changelog/commit/e2036d5ad331c5c02a68394b164b5658bbc39ceb))
+* update ([af48137](https://github.com/obany/changelog/commit/af4813774073de10838b9a8c2bce220bd02fc198))
+* update index ([2b484c3](https://github.com/obany/changelog/commit/2b484c3baa261b75a4f6874cb930e4523a9f3fec))
+* update release strategy ([42edbba](https://github.com/obany/changelog/commit/42edbba7ff7ca9b934bd982dca80d0329db0153b))
+
+
+### Bug Fixes
+
+* changelog paths ([c1a8770](https://github.com/obany/changelog/commit/c1a8770443c49091e15af80d6a3dec4b74dbf4b7))
+* generate-release-configs ([2be7d43](https://github.com/obany/changelog/commit/2be7d431deef5e7fd0442d3c509b91a2d2464597))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * package-a bumped from 0.0.1-next.26 to 0.1.0-next.26
+
+## Changelog

--- a/packages/package-b/package.json
+++ b/packages/package-b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "package-b",
-  "version": "0.0.1-next.26",
+  "version": "0.1.0-next.26",
   "private": true,
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "package-a": "0.0.1-next.26"
+    "package-a": "0.1.0-next.26"
   },
   "author": "",
   "license": "ISC",

--- a/release/release-please-manifest.prerelease.json
+++ b/release/release-please-manifest.prerelease.json
@@ -1,4 +1,4 @@
 {
-	"packages/package-a": "0.0.1-next.26",
-	"packages/package-b": "0.0.1-next.26"
+	"packages/package-a": "0.1.0-next.26",
+	"packages/package-b": "0.1.0-next.26"
 }


### PR DESCRIPTION
:robot: prerelease release prepared
---


<details><summary>package-a: 0.1.0-next.26</summary>

## [0.1.0-next.26](https://github.com/obany/changelog/compare/package-a-v0.0.1-next.26...package-a-v0.1.0-next.26) (2025-03-21)


### Features

* add index ([4db06e7](https://github.com/obany/changelog/commit/4db06e7a1f16a4b04f73739e10c54dcfd6d71db7))
* extra-files ([550996a](https://github.com/obany/changelog/commit/550996ae841df19ecd6713f75444f4d5b75baa57))
* include dot in next prerelease type ([090bbdf](https://github.com/obany/changelog/commit/090bbdff4466909bbdaaf27a61dd0d1bf8bac4d2))
* include dot in next prerelease type ([f627ab9](https://github.com/obany/changelog/commit/f627ab9c3b24536b1b59aae93333e982efef9773))
* initial commit ([b9378bc](https://github.com/obany/changelog/commit/b9378bc2766ab8c0f693c839d37e3e345eadde71))
* initial commit ([6d7e83e](https://github.com/obany/changelog/commit/6d7e83e5be444b7e470a04771efce6cb8de1ac4f))
* package a update ([79055ed](https://github.com/obany/changelog/commit/79055ede87bb9a8df9bf9395597df97f4f7dbf36))
* update ([af48137](https://github.com/obany/changelog/commit/af4813774073de10838b9a8c2bce220bd02fc198))
* update index ([3a2fc61](https://github.com/obany/changelog/commit/3a2fc61aced046b3e10ffae16d344dc66093e504))


### Bug Fixes

* changelog paths ([c1a8770](https://github.com/obany/changelog/commit/c1a8770443c49091e15af80d6a3dec4b74dbf4b7))
* generate-release-configs ([2be7d43](https://github.com/obany/changelog/commit/2be7d431deef5e7fd0442d3c509b91a2d2464597))
</details>

<details><summary>package-b: 0.1.0-next.26</summary>

## [0.1.0-next.26](https://github.com/obany/changelog/compare/package-b-v0.0.1-next.26...package-b-v0.1.0-next.26) (2025-03-21)


### Features

* add index ([4db06e7](https://github.com/obany/changelog/commit/4db06e7a1f16a4b04f73739e10c54dcfd6d71db7))
* extra-files ([550996a](https://github.com/obany/changelog/commit/550996ae841df19ecd6713f75444f4d5b75baa57))
* include dot in next prerelease type ([090bbdf](https://github.com/obany/changelog/commit/090bbdff4466909bbdaaf27a61dd0d1bf8bac4d2))
* include dot in next prerelease type ([f627ab9](https://github.com/obany/changelog/commit/f627ab9c3b24536b1b59aae93333e982efef9773))
* initial commit ([b9378bc](https://github.com/obany/changelog/commit/b9378bc2766ab8c0f693c839d37e3e345eadde71))
* initial commit ([6d7e83e](https://github.com/obany/changelog/commit/6d7e83e5be444b7e470a04771efce6cb8de1ac4f))
* package b update ([e2036d5](https://github.com/obany/changelog/commit/e2036d5ad331c5c02a68394b164b5658bbc39ceb))
* update ([af48137](https://github.com/obany/changelog/commit/af4813774073de10838b9a8c2bce220bd02fc198))
* update index ([2b484c3](https://github.com/obany/changelog/commit/2b484c3baa261b75a4f6874cb930e4523a9f3fec))
* update release strategy ([42edbba](https://github.com/obany/changelog/commit/42edbba7ff7ca9b934bd982dca80d0329db0153b))


### Bug Fixes

* changelog paths ([c1a8770](https://github.com/obany/changelog/commit/c1a8770443c49091e15af80d6a3dec4b74dbf4b7))
* generate-release-configs ([2be7d43](https://github.com/obany/changelog/commit/2be7d431deef5e7fd0442d3c509b91a2d2464597))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * package-a bumped from 0.0.1-next.26 to 0.1.0-next.26
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).