### PR TITLE
chore: release main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3018,14 +3018,14 @@
       }
     },
     "packages/package-a": {
-      "version": "0.0.1-next.27",
+      "version": "0.0.1-next.28",
       "license": "ISC"
     },
     "packages/package-b": {
-      "version": "0.0.1-next.27",
+      "version": "0.0.1-next.28",
       "license": "ISC",
       "dependencies": {
-        "package-a": "0.0.1-next.27"
+        "package-a": "0.0.1-next.28"
       }
     }
   }

--- a/packages/package-a/docs/changelog.md
+++ b/packages/package-a/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.1-next.28](https://github.com/obany/changelog/compare/package-a-v0.0.1-next.27...package-a-v0.0.1-next.28) (2025-03-24)
+
+
+### Features
+
+* update code ([a65283c](https://github.com/obany/changelog/commit/a65283c36f5adc39360670308442f50ca47a4bbe))
+
 ## [0.0.1-next.27](https://github.com/obany/changelog/compare/package-a-v0.0.1-next.26...package-a-v0.0.1-next.27) (2025-03-21)
 
 

--- a/packages/package-a/package.json
+++ b/packages/package-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-a",
-  "version": "0.0.1-next.27",
+  "version": "0.0.1-next.28",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/package-b/docs/changelog.md
+++ b/packages/package-b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.0.1-next.28](https://github.com/obany/changelog/compare/package-b-v0.0.1-next.27...package-b-v0.0.1-next.28) (2025-03-24)
+
+
+### Miscellaneous Chores
+
+* **package-b:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * package-a bumped from 0.0.1-next.27 to 0.0.1-next.28
+
 ## [0.0.1-next.27](https://github.com/obany/changelog/compare/package-b-v0.0.1-next.26...package-b-v0.0.1-next.27) (2025-03-21)
 
 

--- a/packages/package-b/package.json
+++ b/packages/package-b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "package-b",
-  "version": "0.0.1-next.27",
+  "version": "0.0.1-next.28",
   "private": true,
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "package-a": "0.0.1-next.27"
+    "package-a": "0.0.1-next.28"
   },
   "author": "",
   "license": "ISC",

--- a/release/release-please-manifest.prerelease.json
+++ b/release/release-please-manifest.prerelease.json
@@ -1,4 +1,4 @@
 {
-	"packages/package-a": "0.0.1-next.27",
-	"packages/package-b": "0.0.1-next.27"
+	"packages/package-a": "0.0.1-next.28",
+	"packages/package-b": "0.0.1-next.28"
 }


### PR DESCRIPTION
:robot: prerelease release prepared
---


<details><summary>package-a: 0.0.1-next.28</summary>

## [0.0.1-next.28](https://github.com/obany/changelog/compare/package-a-v0.0.1-next.27...package-a-v0.0.1-next.28) (2025-03-24)


### Features

* update code ([a65283c](https://github.com/obany/changelog/commit/a65283c36f5adc39360670308442f50ca47a4bbe))
</details>

<details><summary>package-b: 0.0.1-next.28</summary>

## [0.0.1-next.28](https://github.com/obany/changelog/compare/package-b-v0.0.1-next.27...package-b-v0.0.1-next.28) (2025-03-24)


### Miscellaneous Chores

* **package-b:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * package-a bumped from 0.0.1-next.27 to 0.0.1-next.28
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).